### PR TITLE
Include muting replay warnings and ncp ciphers

### DIFF
--- a/src/python/openvpn3/ConfigParser.py
+++ b/src/python/openvpn3/ConfigParser.py
@@ -750,6 +750,20 @@ class ConfigParser():
                              help='Silence repeating messages during n '
                              + 'seconds. Not supported in OpenVPN3')
 
+        ignored.add_argument('--mute-replay-warnings',
+                             metavar='SECS',
+                             action=ConfigParser.IgnoreArg,
+                             nargs=0,
+                             help='Silence the output of replay warnings. '
+                             + 'Not supported in OpenVPN3')
+
+        ignored.add_argument('--ncp-ciphers',
+                             metavar='ALG',
+                             action=ConfigParser.IgnoreArg,
+                             nargs=1,
+                             help='Restrict the allowed ciphers to be '
+                             + 'negotiated. Not supported in OpenVPN3')
+
         ignored.add_argument('--nice',
                              metavar='LEVEL',
                              action=ConfigParser.IgnoreArg,


### PR DESCRIPTION
Recently, I was trying to include some configuration files from Windscribe when I noticed that `--ncp-ciphers` and `--mute-replay-warnings` led to errors with the autoloader. Looking at the documentation, it seems that these flags are not currently supported by OpenVPN 3. Hope this PR helps!