### PR TITLE
Fix non-systemd build

### DIFF
--- a/src/log/logwriters/journald.cpp
+++ b/src/log/logwriters/journald.cpp
@@ -23,6 +23,10 @@
  * @brief  Implementation of JournaldWriter
  */
 
+#include "config.h"
+
+#ifdef HAVE_SYSTEMD
+
 #include <sys/uio.h>
 #include <ctype.h>
 #include <string>
@@ -33,8 +37,6 @@
 #include "log/logwriter.hpp"
 #include "log/logwriters/journald.hpp"
 
-
-#ifdef HAVE_SYSTEMD
 
 JournaldWriter::JournaldWriter()
     : LogWriter()


### PR DESCRIPTION
When building in a non-systemd environment, `#include <systemd/sd-journal.h>` causes the build to break.